### PR TITLE
Fixed bug in dtnum that breaks for ver<2014a

### DIFF
--- a/+fred/dtnum.m
+++ b/+fred/dtnum.m
@@ -1,12 +1,12 @@
 function [outdate] = dtnum(indate)
-
-  fred_fmt = 'yyyy-mm-dd';
+% FRED.DTNUM datenum for arguments of type char or cell
+%  OUTDATE = FRED.DTNUM(INDATE) returns datenum(s) for each date in INDATE.
 
   if ischar(indate)
     indate = {indate};
   end
   if iscell(indate)
-    outdate = cellfun(@(in) datenum(in, fred_fmt), indate);
+    outdate = cellfun(@(in) datenum(in), indate);
   else
     outdate = indate;
   end


### PR DESCRIPTION
fred.dtnum takes as input a string or cell array of strings and returns
Matlab datenums. Given these inputs, there is no requirement that the
input strings conform to the format 'yyyy-mm-dd'. This was breaking for
versions <2014a. For 2014a, the call to fred.dtnum(date()) was parsing a
date that is by default in format dd-mmm-yyyy as the above format,
returning a date in 2035.
