### PR TITLE
Fixed bug where a series with gaps wouldn't load properly.

### DIFF
--- a/+fred/latest_.m
+++ b/+fred/latest_.m
@@ -45,7 +45,7 @@ function [data] = latest_(series)
 
 
   %% Parse the data
-  date_value = textscan(data_str, '%s\t%f');
+  date_value = textscan(data_str, '%s\t%s');
 
 
   %% Store and return
@@ -56,7 +56,7 @@ function [data] = latest_(series)
   data.pseudo    = NaN;
   data.realtime  = fred.dtnum(datestr(date(), 'yyyy-mm-dd'), 1);
   data.date      = fred.dtnum(date_value{1}, 1);
-  data.value     = date_value{2};
+  data.value     = str2double(date_value{2});
 
 
 end


### PR DESCRIPTION
Using `latest`, some series that have gaps would not be loaded properly because upon encountering the first gap value, denoted in Fred by a period, the `textscan` in `latest_` would stop scanning. This fixes the issue by loading the entire column of values as a string and then converting it to a number.

Example Series: CUUR0000SEHA